### PR TITLE
4226 ensure exceptions caused by incorrect configurations with keycloak or plug in are visible in sentry

### DIFF
--- a/loki-rules/heroku-logs.yaml
+++ b/loki-rules/heroku-logs.yaml
@@ -87,4 +87,11 @@ groups:
           for: 1m
           annotations:
               description: Keycloak is unable to decrypt a SAML assertion likely caused by an internal or external configuration change.
+        - alert: KeycloakServerError
+          expr: '{application="keycloak"} |= `Uncaught server error`'
+          labels:
+              severity: critical
+          for: 1m
+          annotations:
+              description: Keycloak experienced an error condition that is likely the result of a customization.
 

--- a/loki-rules/heroku-logs.yaml
+++ b/loki-rules/heroku-logs.yaml
@@ -71,3 +71,20 @@ groups:
               severity: critical
             annotations:
               description: An invalid username and password message was detected from content sync. This refer to the password used by OCW to talk to concourse. 
+    - name: keycloak
+      rules:
+        - alert: KeycloakInternalError
+          expr: '{application="keycloak"} |= `HTTP 500 Internal Server Error`'
+          labels:
+              severity: critical
+          for: 1m
+          annotations:
+              description: Keycloak has responded with a 500 error which is likely caused by a custimization or configuration change.
+        - alert: KeycloakSAMLAssertionDecryptError
+          expr: '{application="keycloak"} |= `Not possible to decrypt SAML assertion`'
+          labels:
+              severity: warning
+          for: 1m
+          annotations:
+              description: Keycloak is unable to decrypt a SAML assertion likely caused by an internal or external configuration change.
+


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/4226

### Description (What does it do?)
Adds 3 alerts for Keycloak based on text found in the Heroku logs.

The errors associated with the alerts are described here:
https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit?pli=1#heading=h.dyya7brw66hp
