### PR TITLE
Add cert-manager Loki alerting rules

### DIFF
--- a/loki-rules/cert-manager.yaml
+++ b/loki-rules/cert-manager.yaml
@@ -5,9 +5,10 @@ groups:
     rules:
       - alert: CertManagerACMEIssuerUnavailableProduction
         expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
-        for: 1m
+        for: 5m
         labels:
           severity: critical
+          environment: production
         annotations:
           description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. All certificate renewals are blocked until resolved.
           resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
@@ -17,6 +18,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          environment: production
         annotations:
           description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
           resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.
@@ -26,9 +28,10 @@ groups:
     rules:
       - alert: CertManagerACMEIssuerUnavailableNonProd
         expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster!~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
-        for: 1m
+        for: 5m
         labels:
           severity: warning
+          environment: non-production
         annotations:
           description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. Certificate renewals are blocked in this environment.
           resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
@@ -38,6 +41,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          environment: non-production
         annotations:
           description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
           resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.

--- a/loki-rules/cert-manager.yaml
+++ b/loki-rules/cert-manager.yaml
@@ -1,0 +1,43 @@
+namespace: cert-manager
+groups:
+  - name: cert-manager-production
+    interval: 5m
+    rules:
+      - alert: CertManagerACMEIssuerUnavailableProduction
+        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. All certificate renewals are blocked until resolved.
+          resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
+
+      - alert: CertManagerChallengePresentationFailureProduction
+        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "error presenting challenge" [15m])) > 1'
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
+          resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.
+
+  - name: cert-manager-non-production
+    interval: 5m
+    rules:
+      - alert: CertManagerACMEIssuerUnavailableNonProd
+        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster!~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. Certificate renewals are blocked in this environment.
+          resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
+
+      - alert: CertManagerChallengePresentationFailureNonProd
+        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster!~".*-production"} |= "error presenting challenge" [15m])) > 1'
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
+          resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `loki-rules/cert-manager.yaml` with four Loki log-based alerts covering two actionable failure modes in cert-manager, each split by production (critical) and non-production (warning) severity:

- **CertManagerACMEIssuerUnavailable** — fires when cert-manager logs `"ACME client for issuer not initialised/available"` more than 3 times in a 15-minute window. This condition completely blocks all certificate renewals and was observed in a burst of 16+ errors on 2026-06-03 in `applications-production`. The threshold of 3 avoids false positives from a single pod restart.

- **CertManagerChallengePresentationFailure** — fires on `"error presenting challenge"`, which indicates a DNS-01 challenge could not be created (typically a Route 53 IAM permissions or ClusterIssuer config issue). This pattern is intentionally distinct from `"error cleaning up challenge"`, which only appears in the post-issuance cleanup path and is a known benign Route 53 eventual-consistency race that fires on every successful renewal.

Both log patterns were validated against production Loki data before writing the rules.

### How can this be tested?
Log patterns can be verified in Grafana Loki using:
- `{app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "ACME client for issuer not initialised/available"`
- `{app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "error presenting challenge"`

The ACME issuer pattern will return results from the June 3rd incident. The challenge presentation pattern correctly returns no results, confirming it does not match the benign cleanup noise.