### PR TITLE
Fix alert bugs and add EKS pod/node/job/HPA alerts

### DIFF
--- a/alertmanager.yaml
+++ b/alertmanager.yaml
@@ -25,7 +25,7 @@ route:
     receiver: oblivion 
     continue: false
     # Dump the built in kubernetes alerts to oblivion
-  - matcher:
+  - matchers:
     - alertname=~"Kube.*"
     receiver: oblivion
     continue: false

--- a/cortex-rules/eks_general.yaml
+++ b/cortex-rules/eks_general.yaml
@@ -10,7 +10,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          description: There is a mismatch between the requested number of instances for daemonset {{ $labels.daemonset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}. This may mean there is a node stuck leaving or joining the cluster or another issue preventing the daemonset from being correctly scheduled. 
+          description: There is a mismatch between the requested number of instances for daemonset {{ $labels.daemonset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}. This may mean there is a node stuck leaving or joining the cluster or another issue preventing the daemonset from being correctly scheduled.
       - alert: DaemonsetReplicasMissingCritical
         expr: |-
           sum by (cluster, namespace, daemonset) (kube_daemonset_status_current_number_scheduled{cluster=~".*-(production)"}) / sum by (cluster, namespace, daemonset) (kube_daemonset_status_desired_number_scheduled) < 1.0
@@ -18,7 +18,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          description: There is a mismatch between the requested number of instances for daemonset {{ $labels.daemonset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}. This may mean there is a node stuck leaving or joining the cluster or another issue preventing the daemonset from being correctly scheduled. 
+          description: There is a mismatch between the requested number of instances for daemonset {{ $labels.daemonset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}. This may mean there is a node stuck leaving or joining the cluster or another issue preventing the daemonset from being correctly scheduled.
 
       - alert: DeploymentReplicasMissingCritical
         expr: |-
@@ -33,14 +33,13 @@ groups:
           sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(ci|qa)"}) / sum by (cluster, namespace, deployment) (kube_deployment_status_replicas) < 1.0
         for: 10m
         labels:
-          severity: Warning
+          severity: warning
         annotations:
           description: There is a mismatch between the requested number of instances for deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}.
 
-
       - alert: DeploymentUnavailableWarning
         expr: |-
-          sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(production)", condition="Available", status="false"}) > 0
+          sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(ci|qa)", condition="Available", status="false"}) > 0
         for: 10m
         labels:
           severity: warning
@@ -48,11 +47,119 @@ groups:
           description: A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time.
       - alert: DeploymentUnavailableCritical
         expr: |-
-          sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(ci|qa)", condition="Available", status="false"}) > 0
+          sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(production)", condition="Available", status="false"}) > 0
         for: 10m
         labels:
           severity: critical
         annotations:
           description: A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time.
 
+      - alert: StatefulSetReplicasMissingWarning
+        expr: |-
+          sum by (cluster, namespace, statefulset) (kube_statefulset_status_replicas_ready{cluster=~".*-(ci|qa)"}) / sum by (cluster, namespace, statefulset) (kube_statefulset_replicas) < 1.0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: There is a mismatch between the requested number of instances for statefulset {{ $labels.statefulset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}.
+      - alert: StatefulSetReplicasMissingCritical
+        expr: |-
+          sum by (cluster, namespace, statefulset) (kube_statefulset_status_replicas_ready{cluster=~".*-(production)"}) / sum by (cluster, namespace, statefulset) (kube_statefulset_replicas) < 1.0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          description: There is a mismatch between the requested number of instances for statefulset {{ $labels.statefulset }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}.
 
+      - alert: NodeNotReadyWarning
+        expr: |-
+          sum by (cluster, node) (kube_node_status_condition{cluster=~".*-(ci|qa)", condition="Ready", status="true"} == 0)
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Node {{ $labels.node }} in cluster {{ $labels.cluster }} has been in a not-ready state for more than 5 minutes.
+      - alert: NodeNotReadyCritical
+        expr: |-
+          sum by (cluster, node) (kube_node_status_condition{cluster=~".*-(production)", condition="Ready", status="true"} == 0)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: Node {{ $labels.node }} in cluster {{ $labels.cluster }} has been in a not-ready state for more than 5 minutes.
+
+      - alert: PodCrashLoopingWarning
+        expr: |-
+          sum by (cluster, namespace, pod, container) (kube_pod_container_status_waiting_reason{cluster=~".*-(ci|qa)", reason="CrashLoopBackOff"}) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is in CrashLoopBackOff.
+      - alert: PodCrashLoopingCritical
+        expr: |-
+          sum by (cluster, namespace, pod, container) (kube_pod_container_status_waiting_reason{cluster=~".*-(production)", reason="CrashLoopBackOff"}) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is in CrashLoopBackOff.
+
+      - alert: PodOOMKilledWarning
+        expr: |-
+          sum by (cluster, namespace, pod, container) (
+            (kube_pod_container_status_last_terminated_reason{cluster=~".*-(ci|qa)", reason="OOMKilled"} == 1)
+            * on (cluster, namespace, pod, container) group_left()
+            (increase(kube_pod_container_status_restarts_total[1h]) > 0)
+          )
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is actively restarting. Memory limits may need to be increased.
+      - alert: PodOOMKilledCritical
+        expr: |-
+          sum by (cluster, namespace, pod, container) (
+            (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)
+            * on (cluster, namespace, pod, container) group_left()
+            (increase(kube_pod_container_status_restarts_total[1h]) > 0)
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is actively restarting. Memory limits may need to be increased.
+
+      - alert: KubernetesJobFailedWarning
+        expr: |-
+          sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(ci|qa)", namespace!="dagster"} > 0)
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed.
+      - alert: KubernetesJobFailedCritical
+        expr: |-
+          sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(production)", namespace!="dagster"} > 0)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed.
+
+      - alert: HPAAtMaxReplicasWarning
+        expr: |-
+          sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(ci|qa)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"})
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          description: HPA {{ $labels.horizontalpodautoscaler }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been at its maximum replica count for 15 minutes. The workload may be unable to scale further under load.
+      - alert: HPAAtMaxReplicasCritical
+        expr: |-
+          sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"})
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          description: HPA {{ $labels.horizontalpodautoscaler }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been at its maximum replica count for 15 minutes. The workload may be unable to scale further under load.

--- a/cortex-rules/linux-host.yaml
+++ b/cortex-rules/linux-host.yaml
@@ -6,8 +6,8 @@ groups:
         - alert: CPUUsageWarning
           expr: |-
             1 - (
-              sum by (instance) (rate(host_cpu_seconds_total{mode="idle", job="integrations/linux_host"}[5m]))
-              / sum by (instance) (rate(host_cpu_seconds_total{job="integrations/linux_host"}[5m]))
+              sum by (cluster, instance) (rate(host_cpu_seconds_total{mode="idle", job="integrations/linux_host"}[5m]))
+              / sum by (cluster, instance) (rate(host_cpu_seconds_total{job="integrations/linux_host"}[5m]))
             ) > 0.8
           for: 6h
           labels:

--- a/cortex-rules/linux-host.yaml
+++ b/cortex-rules/linux-host.yaml
@@ -5,7 +5,10 @@ groups:
       rules:
         - alert: CPUUsageWarning
           expr: |-
-            1 - sum(rate(host_cpu_seconds_total{host="$instance",mode="idle"}[5m])) / count(count by(cpu) (host_cpu_seconds_total{host="$instance",mode="idle"})) > 0.8
+            1 - (
+              sum by (instance) (rate(host_cpu_seconds_total{mode="idle", job="integrations/linux_host"}[5m]))
+              / sum by (instance) (rate(host_cpu_seconds_total{job="integrations/linux_host"}[5m]))
+            ) > 0.8
           for: 6h
           labels:
             severity: warning


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Addresses bugs and gaps identified in an audit of the existing alert rules against live Grafana/Prometheus data.

#### Bug fixes

**`alertmanager.yaml`**
- `matcher:` (singular) → `matchers:` on the `Kube.*` suppression route. The singular key is not valid in Alertmanager's route config and may have caused the rule to not parse correctly.

**`cortex-rules/eks_general.yaml`**
- `DeploymentUnavailableWarning` and `DeploymentUnavailableCritical` had their cluster selectors swapped: Warning was firing on `.*-production` clusters and Critical was firing on `.*-(ci|qa)` clusters. Fixed so severity matches environment tier.
- `DeploymentReplicasMissingWarning` had `severity: Warning` (capital W). Alertmanager route matchers are case-sensitive, so this alert was silently hitting the `oblivion` receiver instead of Rootly.

**`cortex-rules/linux-host.yaml`**
- `CPUUsageWarning` used `{host="$instance"}` in the PromQL expression. `$instance` is a Grafana dashboard template variable that does not resolve in alert rule evaluation, so the alert never matched any host. Replaced with a correct per-instance expression using `job="integrations/linux_host"` and `sum/sum by (instance)`.

#### New alerts (`cortex-rules/eks_general.yaml`)

All new alerts follow the existing Warning (ci|qa) / Critical (production) pattern.

- **StatefulSetReplicasMissing** — mirrors the existing Deployment and DaemonSet replica mismatch alerts; StatefulSets were the only workload type without coverage.
- **NodeNotReady** — fires when `kube_node_status_condition{condition="Ready",status="true"} == 0` for more than 5 minutes.
- **PodCrashLooping** — fires on `kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}`. Confirmed against live data: a `tika` pod in `applications-production` is currently in this state with no existing alert coverage.
- **PodOOMKilled** — fires when a container's last termination reason is OOMKilled AND it has had restarts in the last hour. The `increase(...[1h]) > 0` guard prevents the alert from staying open indefinitely for historical OOM events. Confirmed against live data: multiple pods in `applications-production` and `data-production` (including `cms-edxapp-app`, `mitlearn-default-celery-worker`, `superset`, `keda-operator`) are actively OOMKilling with no existing alert coverage.
- **KubernetesJobFailed** — fires on `kube_job_status_failed > 0`. The `dagster` namespace is excluded because Dagster creates a Kubernetes Job object per pipeline run; failures there are managed and surfaced by Dagster itself. Confirmed against live data: 5 failed Dagster jobs were visible and would have caused immediate noise without the exclusion.
- **HPAAtMaxReplicas** — fires when `current_replicas >= max_replicas` sustained for 15 minutes, indicating the workload cannot scale further under load.

### How can this be tested?
The following queries can be used to verify the alert expressions return data against live metrics:

- CrashLoopBackOff: `kube_pod_container_status_waiting_reason{cluster=~".*-production", reason="CrashLoopBackOff"}`
- OOMKilled (active): `kube_pod_container_status_last_terminated_reason{cluster=~".*-production", reason="OOMKilled"}`
- Failed jobs (non-dagster): `kube_job_status_failed{cluster=~".*-production", namespace!="dagster"} > 0`