### PR TITLE
Tune cert-manager ACME startup alert

### DIFF
--- a/loki-rules/cert-manager.yaml
+++ b/loki-rules/cert-manager.yaml
@@ -4,44 +4,98 @@ groups:
     interval: 5m
     rules:
       - alert: CertManagerACMEIssuerUnavailableProduction
-        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
-        for: 5m
+        expr: >-
+          sum by (cluster) (
+            count_over_time(
+              {app_kubernetes_io_name="cert-manager", cluster=~".*-production"}
+              |= "ACME client for issuer not initialised/available" [15m]
+            )
+          ) > 3
+        # cert-manager can emit a short burst of these errors during pod
+        # startup while the ACME issuer cache initializes. Require the
+        # condition to outlast the 15m lookback window so transient startup
+        # bursts do not page.
+        for: 20m
         labels:
           severity: critical
           environment: production
         annotations:
-          description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. All certificate renewals are blocked until resolved.
-          resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
+          description: >-
+            cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer
+            outside of the expected pod startup initialization window. All
+            certificate renewals are blocked until resolved.
+          resolution: >-
+            Check cert-manager pod logs and verify network connectivity to the
+            ACME API. May indicate a network policy, DNS resolution failure, or
+            a misconfigured ClusterIssuer credential.
 
       - alert: CertManagerChallengePresentationFailureProduction
-        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster=~".*-production"} |= "error presenting challenge" [15m])) > 1'
+        expr: >-
+          sum by (cluster) (
+            count_over_time(
+              {app_kubernetes_io_name="cert-manager", cluster=~".*-production"}
+              |= "error presenting challenge" [15m]
+            )
+          ) > 1
         for: 5m
         labels:
           severity: critical
           environment: production
         annotations:
-          description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
-          resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.
+          description: >-
+            cert-manager in {{ $labels.cluster }} is failing to present ACME
+            DNS-01 challenges. Certificate issuance will fail until resolved.
+          resolution: >-
+            Check IAM permissions for the Route 53 hosted zone used by the
+            cert-manager challenge solver and verify the ClusterIssuer DNS
+            provider configuration.
 
   - name: cert-manager-non-production
     interval: 5m
     rules:
       - alert: CertManagerACMEIssuerUnavailableNonProd
-        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster!~".*-production"} |= "ACME client for issuer not initialised/available" [15m])) > 3'
-        for: 5m
+        expr: >-
+          sum by (cluster) (
+            count_over_time(
+              {app_kubernetes_io_name="cert-manager", cluster!~".*-production"}
+              |= "ACME client for issuer not initialised/available" [15m]
+            )
+          ) > 3
+        # cert-manager can emit a short burst of these errors during pod
+        # startup while the ACME issuer cache initializes. Require the
+        # condition to outlast the 15m lookback window so transient startup
+        # bursts do not alert.
+        for: 20m
         labels:
           severity: warning
           environment: non-production
         annotations:
-          description: cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer. Certificate renewals are blocked in this environment.
-          resolution: Check cert-manager pod logs and verify network connectivity to the ACME API. May indicate a network policy, DNS resolution failure, or a misconfigured ClusterIssuer credential.
+          description: >-
+            cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer
+            outside of the expected pod startup initialization window.
+            Certificate renewals are blocked in this environment.
+          resolution: >-
+            Check cert-manager pod logs and verify network connectivity to the
+            ACME API. May indicate a network policy, DNS resolution failure, or
+            a misconfigured ClusterIssuer credential.
 
       - alert: CertManagerChallengePresentationFailureNonProd
-        expr: 'sum by (cluster) (count_over_time({app_kubernetes_io_name="cert-manager", cluster!~".*-production"} |= "error presenting challenge" [15m])) > 1'
+        expr: >-
+          sum by (cluster) (
+            count_over_time(
+              {app_kubernetes_io_name="cert-manager", cluster!~".*-production"}
+              |= "error presenting challenge" [15m]
+            )
+          ) > 1
         for: 5m
         labels:
           severity: warning
           environment: non-production
         annotations:
-          description: cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.
-          resolution: Check IAM permissions for the Route 53 hosted zone used by the cert-manager challenge solver and verify the ClusterIssuer DNS provider configuration.
+          description: >-
+            cert-manager in {{ $labels.cluster }} is failing to present ACME
+            DNS-01 challenges. Certificate issuance will fail until resolved.
+          resolution: >-
+            Check IAM permissions for the Route 53 hosted zone used by the
+            cert-manager challenge solver and verify the ClusterIssuer DNS
+            provider configuration.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This updates the cert-manager ACME issuer unavailable Loki alerts to tolerate the known brief startup window where cert-manager may emit `ACME client for issuer not initialised/available` while its ACME issuer cache initializes.

The alerts now require the condition to persist for 20 minutes, outlasting the existing 15-minute log lookback window. That suppresses pod-startup-induced bursts while still alerting when the error continues beyond startup and indicates a real cert-manager/ACME issuer issue.

The rule file was also reformatted to use YAML folded blocks for long expressions and annotation text.

### How can this be tested?
- Parsed all rule YAML files with Python `yaml.safe_load`.
- Ran pi lens diagnostics against the changed file; no issues reported.
- Verified `loki-rules/cert-manager.yaml` has no lines over 80 characters.
- Confirmed this repo has no `.pre-commit-config.yaml`, so there were no repo-local pre-commit hooks to run.
